### PR TITLE
Makefile: Allow to specify extra cxxflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX ?= g++
-CXXFLAGS=-std=c++11 -O3 -Wall -Werror -Wformat=2 -Wextra -Wwrite-strings -Wno-unused-parameter -Wmissing-format-attribute -Wno-non-template-friend -Woverloaded-virtual -Wcast-qual -Wcast-align -Wconversion -fomit-frame-pointer
+CXXFLAGS=-std=c++11 -O3 -Wall -Werror -Wformat=2 -Wextra -Wwrite-strings -Wno-unused-parameter -Wmissing-format-attribute -Wno-non-template-friend -Woverloaded-virtual -Wcast-qual -Wcast-align -Wconversion -fomit-frame-pointer $(EXTRA_CXXFLAGS)
 
 # Output directories
 SRC_DIR = src


### PR DESCRIPTION
The link errors about undefined references to symbols that involve
types in the std::__cxx11 namespace. It is useful to allow to specify
the extra cxxflags such as 'EXTRA_CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0'
to handle this sort of atempt to link together object files that were
compiled with different values for the _GLIBCXX_USE_CXX11_ABI macro.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>