### PR TITLE
ArachneBlockSignalTest: Remove the check for consumerIsReady == 1

### DIFF
--- a/src/ArachneBlockSignalTest.cc
+++ b/src/ArachneBlockSignalTest.cc
@@ -83,8 +83,6 @@ consumer() {
         uint64_t stopTime = Cycles::rdtsc();
         PerfUtils::Util::serialize();
         latencies[i] = stopTime - beforeSignal;
-        while (consumerIsReady)
-            ;
         consumerIsReady = 1;
     }
 }


### PR DESCRIPTION
Because the consumer always sees consumerIsReady == 0 after signaled
by the producer.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>